### PR TITLE
Fix: simulation result does not get saved

### DIFF
--- a/package/solie/logic/simulation_calculator.py
+++ b/package/solie/logic/simulation_calculator.py
@@ -84,6 +84,7 @@ class CalculationResult(NamedTuple):
     unrealized_changes: Series
     scribbles: dict[Any, Any]
     account_state: AccountState
+    virtual_state: VirtualState
 
 
 class SimulationCalculator:
@@ -199,6 +200,7 @@ class SimulationCalculator:
         unrealized_changes = result.unrealized_changes
         scribbles = result.scribbles
         account_state = result.account_state
+        virtual_state = result.virtual_state
 
         if not self.only_visible and should_calculate:
             await self._save_calculation_results(
@@ -206,6 +208,7 @@ class SimulationCalculator:
                 unrealized_changes,
                 scribbles,
                 account_state,
+                virtual_state,
             )
 
         return CalculationResult(
@@ -213,6 +216,7 @@ class SimulationCalculator:
             unrealized_changes=unrealized_changes,
             scribbles=scribbles,
             account_state=account_state,
+            virtual_state=virtual_state,
         )
 
     async def _play_progress_bar(self) -> None:
@@ -518,18 +522,21 @@ class SimulationCalculator:
 
             scribbles = calculation_output_data[-1].chunk_scribbles
             account_state = calculation_output_data[-1].chunk_account_state
+            virtual_state = calculation_output_data[-1].chunk_virtual_state
 
         else:
             asset_record = previous_state.asset_record
             unrealized_changes = previous_state.unrealized_changes
             scribbles = previous_state.scribbles
             account_state = previous_state.account_state
+            virtual_state = previous_state.virtual_state
 
         return CalculationResult(
             asset_record=asset_record,
             unrealized_changes=unrealized_changes,
             scribbles=scribbles,
             account_state=account_state,
+            virtual_state=virtual_state,
         )
 
     async def _save_calculation_results(
@@ -538,6 +545,7 @@ class SimulationCalculator:
         unrealized_changes: Series,
         scribbles: dict[Any, Any],
         account_state: AccountState,
+        virtual_state: VirtualState,
     ) -> None:
         """Save calculation results to disk."""
         await spawn_blocking(asset_record.to_pickle, self.asset_record_path)
@@ -548,4 +556,6 @@ class SimulationCalculator:
         async with aiofiles.open(self.account_state_path, "wb") as file:
             content = pickle.dumps(account_state)
             await file.write(content)
-        # Note: virtual_state is not saved in the original implementation
+        async with aiofiles.open(self.virtual_state_path, "wb") as file:
+            content = pickle.dumps(virtual_state)
+            await file.write(content)


### PR DESCRIPTION
## Summary
- `SimulationCalculator._save_calculation_results` wrote 4 of the 5 state pickles (`asset_record`, `unrealized_changes`, `scribbles`, `account_state`) but never `virtual_state.pickle`, despite a comment claiming this was intentional.
- `_load_or_create_previous_state` unconditionally tries to read all 5 pickle files inside a single `try` block. Since `virtual_state.pickle` never existed, every load raised `FileNotFoundError`, which was caught and treated as "no previous state" — discarding the other 4 correctly-saved pieces of state too and resetting `calculate_from` back to the start of the year.
- Net effect: simulation progress never actually persisted across runs, matching the report in #146.
- Fix: `virtual_state` is now threaded through `CalculationResult` / `_merge_calculation_results` and written to disk in `_save_calculation_results`, restoring parity with `_load_or_create_previous_state`'s expectations (and with the pre-refactor implementation, which did save it).

Fixes #146

## Test plan
- [x] `ruff check package/solie/logic/simulation_calculator.py` passes
- [x] `python -m py_compile` on the changed file passes
- [ ] Manual verification in the running app: run a simulation, close and reopen the year/strategy tab (or restart the app), confirm the calculation resumes from where it left off instead of recalculating from the start of the year — happy to do this if a maintainer can point me at the quickest way to set up a data folder for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ386AEgV8Z796N4TSJtPn